### PR TITLE
Verwerk pdf's en genereer antwoord in nederlands

### DIFF
--- a/afstuderen/Firstprototype.py
+++ b/afstuderen/Firstprototype.py
@@ -79,6 +79,12 @@ def normalize_for_match(s: str) -> str:
     return s.strip()
 
 def post_chat(messages, timeout=180, stream=False) -> str:
+    sys_msg = {"role": "system", "content": "Antwoord uitsluitend in het Nederlands. Gebruik geen Engels."}
+    try:
+        if not messages or (isinstance(messages, list) and (not messages[0] or messages[0].get("role") != "system")):
+            messages = [sys_msg] + list(messages or [])
+    except Exception:
+        messages = [sys_msg]
     payload = {"model": MODEL_NAME, "messages": messages, "stream": stream}
     r = requests.post(API_URL, json=payload, timeout=timeout, stream=stream)
     r.raise_for_status()

--- a/kernwoorden.py
+++ b/kernwoorden.py
@@ -24,7 +24,6 @@ def query_llama(prompt):
     payload = {
         "model": MODEL_NAME,
         "prompt": prompt,
-        "system": "Beantwoord uitsluitend in het Nederlands. Gebruik geen Engels.",
         "max_tokens": 50,
     }
     try:

--- a/kernwoorden.py
+++ b/kernwoorden.py
@@ -24,6 +24,7 @@ def query_llama(prompt):
     payload = {
         "model": MODEL_NAME,
         "prompt": prompt,
+        "system": "Beantwoord uitsluitend in het Nederlands. Gebruik geen Engels.",
         "max_tokens": 50,
     }
     try:


### PR DESCRIPTION
Add system messages to LLM calls to enforce Dutch language responses.

The model was consistently responding in English despite existing prompt instructions. This change introduces a system-level instruction in the `post_chat` function and the `generate` payload to explicitly command the model to respond exclusively in Dutch, providing a more robust language control mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-e395a191-6714-46c8-8528-bfca5788010a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e395a191-6714-46c8-8528-bfca5788010a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

